### PR TITLE
NPE Fix when coding system is unavailable

### DIFF
--- a/src/main/java/org/snomed/cdsservice/model/CDSTrigger.java
+++ b/src/main/java/org/snomed/cdsservice/model/CDSTrigger.java
@@ -53,7 +53,7 @@ public class CDSTrigger {
 	private Collection<Coding> getIntersection(Collection<Coding> codingsA, Collection<Coding> codingsB) {
 		return codingsA.stream().filter(codingA -> {
 			for (Coding codingB : codingsB) {
-				if (codingA.getSystem().equals(codingB.getSystem()) && codingA.getCode().equals(codingB.getCode())) {
+				if (codingA.getSystem() != null && codingA.getSystem().equals(codingB.getSystem()) && codingA.getCode().equals(codingB.getCode())) {
 					return true;
 				}
 			}


### PR DESCRIPTION
- Fixing NPE when coding system is unavailable 

Example: 
```
"code": {
     "coding": [
                {
                  "code": "39c24e7a-dc87-44e7-bdf2-b923d22c3103",
                  "display": "Hypokalemia (disorder)"
                },
                {
                  "system": "http://snomed.info/sct",
                  "code": "43339004",
                  "display": "Hypokalemia (disorder)"
                }
              ],
      "text": "Hypokalemia (disorder)"
}
```